### PR TITLE
Add CI matrix workflow and PyPI release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: ${{ matrix.os }} / py${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ["3.10", "3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install package and dev deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Run tests
+        run: pytest -v --cov=scythe --cov-report=term-missing
+
+      - name: Smoke-test the CLI
+        run: |
+          scythe --version
+          scythe info
+          scythe scan . --depth 1 --no-artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,12 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  # Force UTF-8 stdio so Rich-rendered output (box drawing, bullets) does
+  # not blow up on Windows runners where the default code page is cp1252.
+  PYTHONIOENCODING: utf-8
+  PYTHONUTF8: "1"
+
 jobs:
   test:
     name: ${{ matrix.os }} / py${{ matrix.python-version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,70 @@
+name: Release to PyPI
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  build:
+    name: Build sdist + wheel
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install build backend
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+
+      - name: Build distributions
+        run: python -m build
+
+      - name: Check distributions
+        run: |
+          pip install twine
+          twine check dist/*
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/scythe
+    permissions:
+      id-token: write   # required for Trusted Publishing (OIDC)
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - uses: pypa/gh-action-pypi-publish@release/v1
+
+  github-release:
+    name: Attach artifacts to GitHub Release
+    needs: publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/*
+          generate_release_notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: pypi
-      url: https://pypi.org/p/scythe
+      url: https://pypi.org/p/scythe-cli
     permissions:
       id-token: write   # required for Trusted Publishing (OIDC)
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .venv
 logs
 scythe.egg-info
+scythe_cli.egg-info
 build

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 > Un outil CLI intelligent pour nettoyer automatiquement les artefacts de build
 
 [![CI](https://github.com/elielMengue/scythe/actions/workflows/ci.yml/badge.svg)](https://github.com/elielMengue/scythe/actions/workflows/ci.yml)
-[![PyPI version](https://img.shields.io/pypi/v/scythe.svg)](https://pypi.org/project/scythe/)
-[![Python versions](https://img.shields.io/pypi/pyversions/scythe.svg)](https://pypi.org/project/scythe/)
+[![PyPI version](https://img.shields.io/pypi/v/scythe-cli.svg)](https://pypi.org/project/scythe-cli/)
+[![Python versions](https://img.shields.io/pypi/pyversions/scythe-cli.svg)](https://pypi.org/project/scythe-cli/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 ![Image externe](https://eliel-mengue.vercel.app/images/scythe.png)
@@ -32,11 +32,13 @@ cd scythe
 pip install -e .
 ```
 
-### Depuis PyPI (à venir)
+### Depuis PyPI
 
 ```bash
-pip install scythe
+pip install scythe-cli
 ```
+
+> Le package s'appelle `scythe-cli` sur PyPI (le nom `scythe` était déjà pris), mais la commande installée et le module Python restent `scythe`.
 
 ##  Usage
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 > Un outil CLI intelligent pour nettoyer automatiquement les artefacts de build
 
+[![CI](https://github.com/elielMengue/scythe/actions/workflows/ci.yml/badge.svg)](https://github.com/elielMengue/scythe/actions/workflows/ci.yml)
+[![PyPI version](https://img.shields.io/pypi/v/scythe.svg)](https://pypi.org/project/scythe/)
+[![Python versions](https://img.shields.io/pypi/pyversions/scythe.svg)](https://pypi.org/project/scythe/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+
 ![Image externe](https://eliel-mengue.vercel.app/images/scythe.png)
 
 ##  Qu'est-ce que c'est ?

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=61.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "scythe"
+name = "scythe-cli"
 version = "0.5.0"
 description = "CLI tools for cleaning artifacts and builds"
 readme = "README.md"

--- a/scythe/banner/banner.py
+++ b/scythe/banner/banner.py
@@ -7,19 +7,20 @@ from rich.panel import Panel
 from rich.text import Text
 from rich import box
 
+from scythe import __version__
+
 console = Console()
 
-BANNER = """
-   ____            __  __       
-  / __/____  ___  / /_/ /  ___  
- _\ \/ __/ |/ / |/ / / _ \/ -_) 
-/___/\__/|___/|___/_/_//_/\__/  
+BANNER = r"""
+   ____            __  __
+  / __/____  ___  / /_/ /  ___
+ _\ \/ __/ |/ / |/ / / _ \/ -_)
+/___/\__/|___/|___/_/_//_/\__/
 
 Build Artifact Cleaner"""
 
 
-
-VERSION = "0.3.0"
+VERSION = __version__
 
 
 def display_banner(show_version: bool = True):


### PR DESCRIPTION
- ci.yml: pytest with coverage on Linux/macOS/Windows x Python 3.10/3.11/3.12, plus a smoke test of the installed `scythe` CLI (scan/info/--version).
- release.yml: triggered on tags `v*`. Builds sdist+wheel, twine-checks them, publishes to PyPI via Trusted Publishing (OIDC, no token), and attaches the artifacts to a GitHub Release with auto-generated notes.
- README: add CI / PyPI version / Python versions / License badges.

To activate PyPI publishing, add a Trusted Publisher on https://pypi.org/manage/account/publishing/ with:
  PyPI Project Name: scythe
  Owner: elielMengue
  Repository: scythe
  Workflow filename: release.yml
  Environment name: pypi