### PR TITLE
fix: respect output file suffix in clean command (#6)

### DIFF
--- a/scythe/cli.py
+++ b/scythe/cli.py
@@ -554,10 +554,10 @@ def clean(ctx, path, interactive, dry_run, depth, force, output, only, older_tha
         "errors": clean_result.errors,
         "skipped": clean_result.skipped
     }
-
     if output:
         output_path = Path(output)
-        output_path.write_text(json.dumps(report, indent=2), encoding='utf-8')
+        output_format = 'json' if output_path.suffix == '.json' else 'csv'
+        save_report(report, output_path, output_format)
         console.print(f"\n[green]✓ Report saved: {output_path}[/green]")
 
 


### PR DESCRIPTION
## 🐛 Fix: clean --output format handling

- Updated clean command to respect output file suffix
- Reused existing save_report function for consistency with scan command
- Supports both JSON and CSV outputs correctly

Closes #6