### PR TITLE
feat: honor NO_COLOR env var and add --no-color flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,29 @@ rather than failing.
 Prints the installed version and the list of supported ecosystems and
 patterns.
 
+## Output
+
+By default, `scythe` uses Rich ANSI-colored output for better readability.
+
+Disable colored output using either the standard `NO_COLOR`
+environment variable:
+
+```bash
+NO_COLOR=1 scythe scan ~/projects
+```
+
+or the top-level `--no-color` flag:
+
+```bash
+scythe --no-color scan ~/projects
+```
+
+This is useful for:
+- screen readers
+- CI logs
+- terminals without ANSI support
+- piping output to files or other tools
+
 ## Supported ecosystems
 
 | Ecosystem      | Marker files                                                              | Artifact patterns                                                                                              |

--- a/scythe/cli.py
+++ b/scythe/cli.py
@@ -121,12 +121,17 @@ def cli(ctx, verbose, no_log_file, quiet, no_color):
     logger = setup_logger(name="scythe", level=log_level, log_file=not no_log_file)
 
     ctx.ensure_object(dict)
+    
+    env_no_color = os.environ.get("NO_COLOR") not in (None, "")
+    disable_color = no_color or env_no_color
+
+    console = Console(no_color=disable_color)
     ctx.obj["logger"] = logger
     ctx.obj["console"] = console
     ctx.obj["quiet"] = quiet
 
     if ctx.invoked_subcommand is None and not quiet:
-        display_header()
+        display_header(console)
 
 
 @cli.command()
@@ -768,7 +773,7 @@ def info(ctx):
     console.print(Panel(info_text, title="Guide", border_style="cyan"))
 
 
-def display_header():
+def display_header(console):
     header = """
     [bold red]SCYTHE[/bold red]
     [yellow]Reclaim disk space in seconds.[/yellow]

--- a/scythe/cli.py
+++ b/scythe/cli.py
@@ -1,7 +1,7 @@
 """
 Command Line Interface - Implemented with Click-Rich
 """
-
+import os
 import click
 import csv
 import json
@@ -59,7 +59,6 @@ def _parse_min_size(value):
         raise click.BadParameter(str(exc), param_hint='--min-size')
 
 
-console = Console()
 
 
 @click.group()
@@ -79,8 +78,13 @@ console = Console()
     is_flag=True,
     help='Suppress decorative output (progress bars, panels, headers). Keeps summary lines and --output writes.',
 )
+@click.option(
+    '--no-color',
+    is_flag=True,
+    help='Disable ANSI colored output.',
+)
 @click.pass_context
-def cli(ctx, verbose, no_log_file, quiet):
+def cli(ctx, verbose, no_log_file, quiet, no_color):
     """
         Scan directories for build artifacts and project metadata.
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -378,7 +378,7 @@ def test_quiet_scan_still_writes_output_file(monkeypatch, tmp_path):
     assert "report is saved" not in invoke.output.lower()
 
 
-def test_quiet_clean_suppresses_decorative_output(monkeypatch, tmp_path):
+    def test_quiet_clean_suppresses_decorative_output(monkeypatch, tmp_path):
     """--quiet on clean drops headers, plan, footer; --output still works."""
     project = _project_with_small_and_large_artifacts(tmp_path)
     for artifact in project.artifacts:
@@ -414,7 +414,7 @@ def test_quiet_clean_suppresses_decorative_output(monkeypatch, tmp_path):
     assert report_path.exists()
 
 
-def test_clean_dry_run_skips_trash_setup(monkeypatch, tmp_path):
+    def test_clean_dry_run_skips_trash_setup(monkeypatch, tmp_path):
     """--dry-run + --trash should NOT create a trash dir or manifest."""
     project_dir = tmp_path / "demo"
     artifact_dir = project_dir / "node_modules"
@@ -451,3 +451,63 @@ def test_clean_dry_run_skips_trash_setup(monkeypatch, tmp_path):
     assert invoke.exit_code == 0
     assert artifact_dir.exists()  # still here
     assert not trash_root.exists()
+    def test_no_color_flag(monkeypatch, tmp_path):
+    """--no-color disables ANSI colored output."""
+    scan_result = ScanResult(
+        root_path=tmp_path,
+        projects=[],
+    )
+
+    monkeypatch.setattr(
+        cli_module,
+        "setup_logger",
+        lambda **_kwargs: logging.getLogger("test-no-color-flag"),
+    )
+    monkeypatch.setattr(
+        cli_module,
+        "scan_directory",
+        lambda **_kwargs: scan_result,
+    )
+
+    runner = CliRunner()
+
+    result = runner.invoke(
+        cli_module.cli,
+        ["--no-log-file", "--no-color", "scan", str(tmp_path)],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    assert "\x1b[" not in result.output
+
+
+    def test_no_color_env(monkeypatch, tmp_path):
+    """NO_COLOR env var disables ANSI colored output."""
+    scan_result = ScanResult(
+        root_path=tmp_path,
+        projects=[],
+    )
+
+    monkeypatch.setenv("NO_COLOR", "1")
+
+    monkeypatch.setattr(
+        cli_module,
+        "setup_logger",
+        lambda **_kwargs: logging.getLogger("test-no-color-env"),
+    )
+    monkeypatch.setattr(
+        cli_module,
+        "scan_directory",
+        lambda **_kwargs: scan_result,
+    )
+
+    runner = CliRunner()
+
+    result = runner.invoke(
+        cli_module.cli,
+        ["--no-log-file", "scan", str(tmp_path)],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    assert "\x1b[" not in result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -378,7 +378,7 @@ def test_quiet_scan_still_writes_output_file(monkeypatch, tmp_path):
     assert "report is saved" not in invoke.output.lower()
 
 
-    def test_quiet_clean_suppresses_decorative_output(monkeypatch, tmp_path):
+def test_quiet_clean_suppresses_decorative_output(monkeypatch, tmp_path):
     """--quiet on clean drops headers, plan, footer; --output still works."""
     project = _project_with_small_and_large_artifacts(tmp_path)
     for artifact in project.artifacts:
@@ -414,7 +414,7 @@ def test_quiet_scan_still_writes_output_file(monkeypatch, tmp_path):
     assert report_path.exists()
 
 
-    def test_clean_dry_run_skips_trash_setup(monkeypatch, tmp_path):
+def test_clean_dry_run_skips_trash_setup(monkeypatch, tmp_path):
     """--dry-run + --trash should NOT create a trash dir or manifest."""
     project_dir = tmp_path / "demo"
     artifact_dir = project_dir / "node_modules"
@@ -451,7 +451,9 @@ def test_quiet_scan_still_writes_output_file(monkeypatch, tmp_path):
     assert invoke.exit_code == 0
     assert artifact_dir.exists()  # still here
     assert not trash_root.exists()
-    def test_no_color_flag(monkeypatch, tmp_path):
+
+
+def test_no_color_flag(monkeypatch, tmp_path):
     """--no-color disables ANSI colored output."""
     scan_result = ScanResult(
         root_path=tmp_path,
@@ -481,7 +483,7 @@ def test_quiet_scan_still_writes_output_file(monkeypatch, tmp_path):
     assert "\x1b[" not in result.output
 
 
-    def test_no_color_env(monkeypatch, tmp_path):
+def test_no_color_env(monkeypatch, tmp_path):
     """NO_COLOR env var disables ANSI colored output."""
     scan_result = ScanResult(
         root_path=tmp_path,


### PR DESCRIPTION
## Summary

Adds support for disabling ANSI-colored output via:

- `NO_COLOR` environment variable
- `--no-color` CLI flag

## Changes

- Added top-level `--no-color` flag
- Honor `NO_COLOR` environment variable
- Configured Rich `Console(no_color=...)`
- Added tests for no-color behavior
- Updated README Output section

Closes #9