### PR TITLE
feat(detector): add Bun ecosystem detection

### DIFF
--- a/scythe/detector/detector.py
+++ b/scythe/detector/detector.py
@@ -25,6 +25,14 @@ ARTIFACT_PATTERNS: Dict[ProjectType, List[str]] = {
         '.turbo',
         'coverage'
     ],
+    
+    ProjectType.BUN: [
+        'node_modules',
+        'dist',
+        'build',
+        '.cache',
+        'coverage'
+    ],
 
     ProjectType.PYTHON: [
         '.venv',

--- a/scythe/models/models.py
+++ b/scythe/models/models.py
@@ -14,6 +14,7 @@ class ProjectType(Enum) :
     """
 
     NODE = "node"
+    BUN = "bun"
     PYTHON = "python"
     RUST = "rust"
     JAVA_MAVEN = "java_maven"
@@ -30,6 +31,7 @@ class ProjectType(Enum) :
     def display_name(self):
         names = {
             ProjectType.NODE : "Node.js",
+            ProjectType.BUN : "Bun",
             ProjectType.PYTHON : "Python",
             ProjectType.RUST : "Rust",
             ProjectType.JAVA_MAVEN : "Java (Maven)",
@@ -52,6 +54,7 @@ class ProjectType(Enum) :
         aliases = {
             "node": cls.NODE,
             "nodejs": cls.NODE,
+            "bun": cls.BUN,
             "js": cls.NODE,
             "python": cls.PYTHON,
             "py": cls.PYTHON,

--- a/scythe/scanner/scanner.py
+++ b/scythe/scanner/scanner.py
@@ -11,7 +11,17 @@ from scythe.logger.logger import get_logger
 from scythe.detector.detector import detect_artifacts
 
 PROJECT_MARKERS = {
-    ProjectType.NODE: ['package.json', 'package-lock.json', 'yarn.lock', 'pnpm-lock.yaml'],
+    ProjectType.NODE: [
+        'package.json',
+        'package-lock.json',
+        'yarn.lock',
+        'pnpm-lock.yaml'
+    ],
+
+    ProjectType.BUN: [
+        'bun.lock',
+        'bun.lockb'
+    ],
     ProjectType.PYTHON: ['requirements.txt', 'setup.py', 'pyproject.toml', 'Pipfile', 'poetry.lock'],
     ProjectType.RUST: ['Cargo.toml', 'Cargo.lock'],
     ProjectType.JAVA_MAVEN: ['pom.xml'],

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -47,3 +47,16 @@ def test_scan_complete(test_project_structure):
     assert ProjectType.NODE in project_types
     assert ProjectType.PYTHON in project_types
     assert ProjectType.RUST in project_types
+    
+def test_detect_bun_project(tmp_path):
+    bun_project = tmp_path / "bun-app"
+    bun_project.mkdir()
+
+    (bun_project / "bun.lock").write_text("")
+
+    scanner = DirectoryScanner(tmp_path, -1)
+    result = scanner.scan()
+
+    project_types = [p.project_type for p in result.projects]
+
+    assert ProjectType.BUN in project_types


### PR DESCRIPTION
## Summary

Adds first-class Bun ecosystem support to scythe.

### Changes

* Added `ProjectType.BUN`
* Added Bun project detection using:

  * `bun.lock`
  * `bun.lockb`
* Added Bun artifact support:

  * `node_modules`
  * `dist`
  * `build`
  * `.cache`
  * `coverage`
* Added scanner test for Bun project detection

This implementation keeps Bun support conservative and aligned with existing Node-style artifact handling.
